### PR TITLE
Update Word_Space.md

### DIFF
--- a/en-US/Word_Space.md
+++ b/en-US/Word_Space.md
@@ -12,23 +12,23 @@ A word space that is too wide or too narrow can ruin the design of a font. It’
 begin considering the word spacing as long as you have your first characters set up. The choice you
 make at this point should be gradually adjusted while you progress in the design of the font.
 
+The word space here is too tight&hellip;
+
 <img src="images/Screen%20Shot%202012-12-06%20at%204.51.42%20PM.png" alt height="251" width="486">
 
-The word space here is too tight&hellip;
+And here, it’s too wide&hellip;
 
 <img src="images/Screen%20Shot%202012-12-06%20at%204.51.16%20PM.png" alt height="273" width="474">
 
-&hellip;and here, it’s too wide.
+Now this is well-balanced&hellip;
 
 <img src="images/Screen%20Shot%202012-12-06%20at%204.49.50%20PM.png" alt height="270" width="466">
 
-Now that’s well-balanced.
-
-If your type is meant to be used at larger sizes, then the word space can be reduced &ndash; and
+If your type is meant to be used at larger sizes, then the word space can be reduced &mdash; and
 *vice-versa* if it’s to be used at very small sizes.
 
 The research has shown that a word space that’s too large is more tolerable than one that’s too
-small; so if you are unsure you may want to error in that direction.
+small, so if you are unsure you may want to err in that direction.
 
 <div class="note"><p><b>Note:</b> Similar studies have shown that younger children in particular
 benefit a little from word spaces larger than what’s considered normal for adult readers.</p>


### PR DESCRIPTION
Changed the way the sentences refer to the 'too tight' and 'too loose' and 'well-balanced' examples. The layout was confusing, and somewhat misleading. I've clarified what is being referred to, by placing the referring line BEFORE each example, and making the position of the ellipsis in each sentence the same.

Line 27: That's an em-dash, not an en-dash. En-dashes are used in number ranges, not as parenthetical dashes.

Line 31: Changed the semi-colon to a comma, as the clause following is a dependent clause. Changed the word 'error' to 'err'.
