### PR TITLE
Correct name of Vollkorn font

### DIFF
--- a/en-US/Numerals.md
+++ b/en-US/Numerals.md
@@ -20,7 +20,7 @@ Having the zero narrower than the capital O while sharing its height is the comm
 
 <img src="images/open-sans-numbers.png" alt="">
 
-A perfectly round or nearly perfectly round circle is less common, but does exist. Examples of fonts that use this approach include the Google web font Volkhorn as well as other commercial types such as Mrs Eaves, Vendeta and Fleischman BT Pro. Fonts that use oldstyle proportional numerals are more likely to feature this approach. Sometimes a zero at x-height but which is narrower will also be seen.
+A perfectly round or nearly perfectly round circle is less common, but does exist. Examples of fonts that use this approach include the Google web font Vollkorn as well as other commercial types such as Mrs Eaves, Vendeta and Fleischman BT Pro. Fonts that use oldstyle proportional numerals are more likely to feature this approach. Sometimes a zero at x-height but which is narrower will also be seen.
 
 Numerals also come in up to 11 identifiable styles when you include fractions, superscripts and subscripts. We will look at the 5 most common ones.
 

--- a/zh-CN/Numerals.md
+++ b/zh-CN/Numerals.md
@@ -20,7 +20,7 @@ title: 数字
 
 <img src="../en-US/images/open-sans-numbers.png" alt="">
 
-一个完美的圆或者接近完美的圆圈不常用，但是也存在。使用这种方法的字体的例子包括Google网页字体Volkhorn和其他商业字体比如Mrs Eaves，Vendeta和Fleischman BT Pro。使用老式的按比例的数字的字体更多地使用了这种方法。有时也会看到一个达到x高度但是更窄的零。
+一个完美的圆或者接近完美的圆圈不常用，但是也存在。使用这种方法的字体的例子包括Google网页字体Vollkorn和其他商业字体比如Mrs Eaves，Vendeta和Fleischman BT Pro。使用老式的按比例的数字的字体更多地使用了这种方法。有时也会看到一个达到x高度但是更窄的零。
 
 当你包含了分数、上标和下标的时候，数字可能有多达11种可以分辨的样式。我们来看其中5种最常见的。
 


### PR DESCRIPTION
The name of the font Vollkorn was misspelled "Volkhorn". I have corrected this in the Markdown files, but not the files in the `ebook` folder.
