### PR TITLE
Use Heuristica as a stand-in for Source Serif's missing italics

### DIFF
--- a/_includes/html-start.html
+++ b/_includes/html-start.html
@@ -4,6 +4,23 @@
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link href='//fonts.googleapis.com/css?family=Julius+Sans+One|Source+Sans+Pro:400,700|Source+Code+Pro|Source+Serif+Pro:400,700' rel='stylesheet' type='text/css'>
+    <style>
+/* Use Heuristica's italics to stand in for the missing Source Serif Pro italics. */
+
+@font-face {
+  font-family: 'Source Serif Pro';
+  font-style: italic;
+  font-weight: 400;
+  src: local('Heuristica Italic'), url(//brick.a.ssl.fastly.net/fonts/heuristica/400i.woff) format('woff');
+}
+
+@font-face{
+  font-family: 'Source Serif Pro';
+  font-style: italic;
+  font-weight: 700;
+  src: local('Heuristica Bold Italic'), url(//brick.a.ssl.fastly.net/fonts/heuristica/700i.woff) format('woff');
+}
+    </style>
     <link rel="stylesheet" type="text/css" href="/assets/stylesheets/stylesheet.css" media="screen">
     <link rel="stylesheet" type="text/css" href="/assets/stylesheets/print.css" media="print">
 

--- a/assets/stylesheets/stylesheet.css
+++ b/assets/stylesheets/stylesheet.css
@@ -341,6 +341,7 @@ form {
 
 em, i {
   font-style: italic;
+  font-size-adjust: 0.47;
 }
 
 b, strong {
@@ -507,6 +508,7 @@ ol li {
 dl dd {
   font-style: italic;
   font-weight: 100;
+  font-size-adjust: 0.47;
 }
 
 footer {


### PR DESCRIPTION
Since this an online book about making fonts, we should use true italics instead of sloped romans. So, shamelessly stealing the idea from the [Rust Language Reference](https://doc.rust-lang.org/nightly/reference.html#character-escapes), I use Heuristica italics to stand-in for Source Serif's missing italics. Only difference is that I also use `font-size-adjust` to match the x-heights. Here's what it would look like:

![Heuristica Italics in action](https://cloud.githubusercontent.com/assets/9031092/12871269/55bfa36c-cdad-11e5-8f02-8e446bbba2cf.png)

And here's the "before" image.

![Sloped Source Serif Pro](https://cloud.githubusercontent.com/assets/9031092/12871271/898cf050-cdad-11e5-89ce-4d104f5ccb4d.png)

I use [brick.im](http://brick.im/) to grab the font, mainly because it's the only source I found that hosts the webfont. It only supports the `.woff` variant, but since I doubt any font designer uses [IE8 or lower](http://caniuse.com/#feat=woff) I think it's good enough.

Edit: Just realize an issue #108 was already filed for this.
