### PR TITLE
Escaped non-typographic quote example to avoid kramdown autoconversion

### DIFF
--- a/en-US/Punctuation_and_Symbols.md
+++ b/en-US/Punctuation_and_Symbols.md
@@ -47,7 +47,7 @@ The design of the c, C, G, s, and S glyphs may provide some basis for the design
 ## Additional symbols
 <img src="images/3quotes.png" alt="">
 
-Simple or vertical quotes -- ' and " -- are distinct from typographic quotes: ‘ ’ and “ ” ‚ „ .
+Simple or vertical quotes -- \' and \" -- are distinct from typographic quotes: ‘ ’ and “ ” ‚ „ .
 
 Simple quotes can follow the shape of the bar over the dot in the exclamation mark, but they can also be designed separately.
 


### PR DESCRIPTION
Kramdown currently converts the sample “simple or vertical quotes”  into the typographic quotes they’re meant to contrast with. [From the live jekyll site](http://designwithfontforge.com/en-US/Punctuation_and_Symbols.html#additional-symbols):

![shot may 31 2016 6 20 04pm](https://cloud.githubusercontent.com/assets/8379226/15692524/f186c2e0-275c-11e6-840b-b185a253415a.jpeg)
