### PR TITLE
Replaced -- sequences with em-dash character (utf-8 8212/0x2014)

### DIFF
--- a/en-US/Bold_and_Other_Weights.md
+++ b/en-US/Bold_and_Other_Weights.md
@@ -10,7 +10,7 @@ When we talk about the style "bold," we are really talking about a broader varia
 
 While you may want to do a wide range of things with weight it is likely that your first experience with adjusting weight will be to try to create a bold to accompany your regular text weight.
 
-Because you are using FontForge you have a distinct advantage. Unlike many font editing programs, the results you get from FontForge style filter may actually be suitable for use -- moreso than the ones you would get in commercial type design software. This is because the algorithm it uses is exceptionally sophisticated.
+Because you are using FontForge you have a distinct advantage. Unlike many font editing programs, the results you get from FontForge style filter may actually be suitable for use — moreso than the ones you would get in commercial type design software. This is because the algorithm it uses is exceptionally sophisticated.
 
 Creating a bold version of a font can be rapidly approximated by running a filter called <em>Change weight</em> (which you will find in the Element &gt; Styles menu) to add weight to your glyphs.
 

--- a/en-US/Completing_the_Lower_Case.md
+++ b/en-US/Completing_the_Lower_Case.md
@@ -14,7 +14,7 @@ Note the similarity between the upper terminals on this c and f:
 
 Their shapes indicate that they belong in the same group, even though they are subtly different. The terminals are one of the identifying traits of a font, and generally are repeated on many of the letter forms.
 
-However, excessive dependence on modularity shows its own marks in a design, and therefore should be avoided -- unless that is a look you want.
+However, excessive dependence on modularity shows its own marks in a design, and therefore should be avoided — unless that is a look you want.
 
 ## Proceeding with the other lower case letters
 

--- a/en-US/Glossary.md
+++ b/en-US/Glossary.md
@@ -38,7 +38,7 @@ The distance between the start of this glyph and the start of the next glyph. So
 
 ### Alphabet
 
-A writing system where there are glyphs for all phonemes -- consonants and vowels alike -- and (in theory anyway) all phonemes in a word will be marked by an appropriate glyph.
+A writing system where there are glyphs for all phonemes — consonants and vowels alike -- and (in theory anyway) all phonemes in a word will be marked by an appropriate glyph.
 
 See Also: abjad, abugida, syllabary and the <a title="Unicode consortium" href="http://en.wikipedia.org/wiki/Alphabet">relevant Wikipedia article</a> (http://en.wikipedia.org/wiki/Alphabet).
 
@@ -212,9 +212,9 @@ An encoding is a mapping from a set of bytes onto a character set. It is what de
 
 In more complicated cases it is possible to have multiple glyphs associated with each character (as in arabic where most characters have at least 4 different glyphs) and the client program must pick the appropriate glyph for the character in the current context.
 
-### Eth -- Edh
+### Eth — Edh
 
-The old germanic letter "&eth;" for the voiced (English) "th" sound (the sound in "this" -- most English speakers aren't even aware that "th" in English has two sounds associated with it, but it does, see also Thorn)
+The old germanic letter "&eth;" for the voiced (English) "th" sound (the sound in "this" — most English speakers aren't even aware that "th" in English has two sounds associated with it, but it does, see also Thorn)
 
 ### Even-Odd Fill rule
 
@@ -286,7 +286,7 @@ The German monks at the time of Gutenberg used a black-letter writing style, and
 
 Graphite is an extension to TrueType which embeds several tables into a font containing rules for contextual shaping, ligatures, reordering, split glyphs, bidirectionality, stacking diacritics, complex positioning, etc.
 
-This sounds rather like OpenType -- except that OpenType depends on the text layout routines knowing a lot about the glyphs involved. This means that OpenType fonts cannot be designed for a new language or script without shipping a new version of the operating system. Whereas Graphite tables contain all that hidden information.
+This sounds rather like OpenType — except that OpenType depends on the text layout routines knowing a lot about the glyphs involved. This means that OpenType fonts cannot be designed for a new language or script without shipping a new version of the operating system. Whereas Graphite tables contain all that hidden information.
 
 Apple's Advanced Typography provides a better comparison, but Graphite tables are supposed to be easier to build.
 
@@ -303,7 +303,7 @@ The ideographic characters used in China, Japan and Korea (and, I believe, in va
 
 ### Hangul
 
-The Korean syllabary. The only syllabary (that I'm aware of anyway) based on an alphabet -- the letters of the alphabet never appear alone, but only as groups of two or three making up a syllable.
+The Korean syllabary. The only syllabary (that I'm aware of anyway) based on an alphabet — the letters of the alphabet never appear alone, but only as groups of two or three making up a syllable.
 
 ### Hanja
 
@@ -335,7 +335,7 @@ Italic differs from Oblique in that the transformation from the plain to the sla
 ## J
 ### Jamo
 
-The letters of the Korean alphabet. These are almost never seen alone, generally appearing in groups of three as part of a Hangul syllable. The Jamo are divided into three categories (with considerable overlap between the first and third), the choseong -- initial consonants, the jungseong -- medial vowels, and the jongseong -- final consonants. A syllable is composed by placing a choseong glyph in the upper left of an em-square, a jungseong in the upper right, and optionally a jongseong in the lower portion of the square.
+The letters of the Korean alphabet. These are almost never seen alone, generally appearing in groups of three as part of a Hangul syllable. The Jamo are divided into three categories (with considerable overlap between the first and third), the choseong — initial consonants, the jungseong -- medial vowels, and the jongseong -- final consonants. A syllable is composed by placing a choseong glyph in the upper left of an em-square, a jungseong in the upper right, and optionally a jongseong in the lower portion of the square.
 
 ## K
 ### Kanji
@@ -467,7 +467,7 @@ This was the early name for FontForge. The original conception was that it would
 
 ### Phantom points
 
-In a TrueType font there are a few points added to each glyph which are not specified by the contours that make up the glyph. These are called phantom points. One of these points represents the left side bearing, and the other the advance width of the glyph. TrueType instructions (hints) are allowed to move these points around just as any other points may be moved -- thus changing the left-side-bearing or the advance width. Early versions of TrueType supplied just these two phantoms, more recent versions also supply a phantom for the top sidebearing and a phantom for the vertical advance width.
+In a TrueType font there are a few points added to each glyph which are not specified by the contours that make up the glyph. These are called phantom points. One of these points represents the left side bearing, and the other the advance width of the glyph. TrueType instructions (hints) are allowed to move these points around just as any other points may be moved — thus changing the left-side-bearing or the advance width. Early versions of TrueType supplied just these two phantoms, more recent versions also supply a phantom for the top sidebearing and a phantom for the vertical advance width.
 
 ### Pica
 
@@ -489,7 +489,7 @@ This has the interesting side effect that a font designed for European usage sho
 
 As far as I can tell, computers tend to work in approximations to pica points (but this may be because I am in the US), PostScript uses a unit of 1/72nd of an inch.
 
-Originally fonts were not described by point size, but by name. It was not until the 1730s that Pierre Fournier that created the point system for specifying font heights. This was later improved upon by Fran&ccedil;ois-Ambroise Didot (hence the name of the point). In 1878 the Chicago Type Foundry first used a point system in the US. In 1886 the US point was standardized -- the pica was defined to be 35/83cm, and the pica point defined to be 1/12th of that.
+Originally fonts were not described by point size, but by name. It was not until the 1730s that Pierre Fournier that created the point system for specifying font heights. This was later improved upon by Fran&ccedil;ois-Ambroise Didot (hence the name of the point). In 1878 the Chicago Type Foundry first used a point system in the US. In 1886 the US point was standardized — the pica was defined to be 35/83cm, and the pica point defined to be 1/12th of that.
 
 ### Point Size
 
@@ -567,7 +567,7 @@ Supplementary Ideographic Plane (0x20000-0x2FFFF) of Unicode. Used for rare Han 
 
 ### SMP
 
-Supplementary Multilingual Plane (0x10000-0x1FFFF) of Unicode. Used for ancient and artificial alphabets and syllabaries -- like Linear B, Gothic, and Shavian. See Also
+Supplementary Multilingual Plane (0x10000-0x1FFFF) of Unicode. Used for ancient and artificial alphabets and syllabaries — like Linear B, Gothic, and Shavian. See Also
 
 * BMP: Basic Multilingual Plane (0x00000-0x0FFFF)
 * SIP: Supplementary Ideographic Plane (0x20000-0x2FFFF)
@@ -662,7 +662,7 @@ A type of PostScript font.
 
 ### Type High
 
-In the days of metal type this was the height of the piece of metal -- the distance from the printing surface to the platform on which it rested.
+In the days of metal type this was the height of the piece of metal — the distance from the printing surface to the platform on which it rested.
 
 ### Typewriter
 

--- a/en-US/Line_Spacing.md
+++ b/en-US/Line_Spacing.md
@@ -14,7 +14,7 @@ As is the case with letter and word spacing, having too much or too little line 
 
 As a general rule, most new font designers tend to err on the side of having too little line spacing in their font, so if you are unsure, adding additional space is usually a good idea.
 
-You should also consider the scope of your project's language coverage when considering line spacing. If you test your font's line spacing only with unaccented characters, you are likely to settle on a line spacing value that leaves no room for accents.  If you are certain your font will never be used with accented characters, this might be acceptable -- but the odds are that your font <em>will</em> be used to set accented text.  In that case, too little line spacing will cause the accents on one line to run into the bottoms of the glyphs above, and leave the reader with difficult (if not impossible) to read text.
+You should also consider the scope of your project's language coverage when considering line spacing. If you test your font's line spacing only with unaccented characters, you are likely to settle on a line spacing value that leaves no room for accents.  If you are certain your font will never be used with accented characters, this might be acceptable — but the odds are that your font <em>will</em> be used to set accented text.  In that case, too little line spacing will cause the accents on one line to run into the bottoms of the glyphs above, and leave the reader with difficult (if not impossible) to read text.
 
 One strategy to test whether your font's line spacing is proper for accented characters is to employ sample text from several languages.
 

--- a/en-US/Numerals.md
+++ b/en-US/Numerals.md
@@ -6,7 +6,7 @@ category: workflow
 title: Numerals
 ---
 
-Numerals are often difficult for font designers -- and for several reasons. One is that numerals have a very large number of curves. Another is that numerals often use conventions in their shapes that are different from (or are even in violation of) the visual conventions seen in the rest of the font design. Furthermore, numerals can have very large number of strokes (like 8 and 5 do), or they may have large white spaces (like 1, 7, and sometimes 2 and 4). Both situations can be hard to manage. Finally, there is the problem of how to make sure your zero looks different from the capital O.
+Numerals are often difficult for font designers — and for several reasons. One is that numerals have a very large number of curves. Another is that numerals often use conventions in their shapes that are different from (or are even in violation of) the visual conventions seen in the rest of the font design. Furthermore, numerals can have very large number of strokes (like 8 and 5 do), or they may have large white spaces (like 1, 7, and sometimes 2 and 4). Both situations can be hard to manage. Finally, there is the problem of how to make sure your zero looks different from the capital O.
 
 It can be useful to look at the numerals found in a wide variety of fonts to become more familiar with the ways in which designers cope with these problems.
 
@@ -14,7 +14,7 @@ In those numerals with a dense number of strokes (such as 8), you may find that 
 
 Conversely, to compensate for numerals with large white space proportions, some strokes are likely to become heavier than would be typical.
 
-In the case of distinguishing the zero from the capital O, there are a wide range of solutions -- such as making the zero narrower than the O, or a zero that is perfectly round, or perhaps (especially in a monospace font) having a slash through the zero.
+In the case of distinguishing the zero from the capital O, there are a wide range of solutions — such as making the zero narrower than the O, or a zero that is perfectly round, or perhaps (especially in a monospace font) having a slash through the zero.
 
 Having the zero narrower than the capital O while sharing its height is the common approach. This approach is typical of lining numerals. Lining numerals are the most common style for numerals. Examples of fonts that use this approach include: many Garamonds, Futura, and the Google web font Open Sans. Below is Open Sans showing the zero, capital O, zero and then other numerals.
 

--- a/en-US/Punctuation_and_Symbols.md
+++ b/en-US/Punctuation_and_Symbols.md
@@ -47,7 +47,7 @@ The design of the c, C, G, s, and S glyphs may provide some basis for the design
 ## Additional symbols
 <img src="images/3quotes.png" alt="">
 
-Simple or vertical quotes -- ' and " -- are distinct from typographic quotes: ‘ ’ and “ ” ‚ „ .
+Simple or vertical quotes — ' and " -- are distinct from typographic quotes: ‘ ’ and “ ” ‚ „ .
 
 Simple quotes can follow the shape of the bar over the dot in the exclamation mark, but they can also be designed separately.
 

--- a/en-US/The_Final_Output_Generating_Font_Files.md
+++ b/en-US/The_Final_Output_Generating_Font_Files.md
@@ -12,7 +12,7 @@ FontForge can export your font to a variety of different formats, but in practic
 
 ## Quick and dirty generation for testing
 
-To build a font file for testing purposes -- such as to examine the spacing in a web browser -- you need only to ensure that your font passes the required validation tests.
+To build a font file for testing purposes — such as to examine the spacing in a web browser -- you need only to ensure that your font passes the required validation tests.
 
 You can use the <em>Validate Font</em> tool found in the Element menu to do this (see the chapter on validating fonts for a more detailed explanation), or you can select all of the glyphs (hit Control-A or choose "Select" -&gt; "Select All" from the "Edit" menu) then run a few commands to apply some basic changes in bulk. Be sure to save your work before you proceed any further, though: some of the changes required to validate your font for export will alter the shapes of your glyphs in subtle ways.
 
@@ -24,7 +24,7 @@ After you can run these tests without errors, you will then need to convert your
 
 ### Building the font files
 
-Open the <em>Generate Fonts</em> window by choosing it from the "File" menu. The top half of the window shows the familiar file-chooser options -- a list of the files found in the current directory, a text-entry box for you to enter a filename, and buttons to navigate to other folders and directories if necessary. This is strictly a means to help you quickly find the right place to save your output file, or to choose an existing font file if you intend to overwrite a previous save. All of the options you need to look at are found in the bottom half of the window.
+Open the <em>Generate Fonts</em> window by choosing it from the "File" menu. The top half of the window shows the familiar file-chooser options — a list of the files found in the current directory, a text-entry box for you to enter a filename, and buttons to navigate to other folders and directories if necessary. This is strictly a means to help you quickly find the right place to save your output file, or to choose an existing font file if you intend to overwrite a previous save. All of the options you need to look at are found in the bottom half of the window.
 
 <img src="images/generate.png" alt="">
 
@@ -34,7 +34,7 @@ Click the "Generate" button, and FontForge will build your font file. You can lo
 
 ## Generating for final release
 
-Designing your font is an iterative process, but eventually the day when come when you must declare your font finished -- or at least ready for public consumption. At that point, you will again generate a .ttf or .otf output file (perhaps even both), but before doing so you will need to work through a few additional steps to create the most standards-compliant and user-friendly version of your font file.
+Designing your font is an iterative process, but eventually the day when come when you must declare your font finished — or at least ready for public consumption. At that point, you will again generate a .ttf or .otf output file (perhaps even both), but before doing so you will need to work through a few additional steps to create the most standards-compliant and user-friendly version of your font file.
 
 First, follow the same preparation steps outlined in the section on quick and dirty generation for testing purposes. In particular, remember to change your font to <em>All layers quadratic</em> if you are creating a TrueType file.
 
@@ -46,7 +46,7 @@ FontForge has a <em>Remove Overlap</em> command that will automatically combine 
 
 ### Simplify contours and add extrema points
 
-You should also simplify your glyphs where possible -- not eliminating details, but eliminating redundant points. This reduces files size slightly for every glyph, which adds up considerably over the entire set of characters in the font.
+You should also simplify your glyphs where possible — not eliminating details, but eliminating redundant points. This reduces files size slightly for every glyph, which adds up considerably over the entire set of characters in the font.
 
 From the "Element" menu, choose "Simplify" -&gt; <em>Simplify</em> (or hit Control-Shift-M). This command will merge away redundant on-curve points in all of the selected glyphs. In some cases, there will be only a few points removed, in others there may be many. But it should perform the simplification without noticeably changing the shape of any glyphs. If you notice a particular glyph that <em>is</em> altered too much by <em>Simplify</em>, feel free to undo the operation. You can also experiment with the <em>Simplify More</em> command also located in the same menu; it offers tweakable parameters that could prove helpful.
 
@@ -101,7 +101,7 @@ If you have made significant changes to other features of your font, it is a goo
 
 The process for generating the font output files is the same when you are building the final release as it is when you are building a quick-and-dirty copy for testing, but you will want to pay closer attention to some of the options.
 
-Open the <em>Generate Fonts</em> window by choosing it from the "File" menu. Again, the top half of the window allows you to choose the directory and file name to give to your output file -- just be careful that you do not overwrite a previous save.
+Open the <em>Generate Fonts</em> window by choosing it from the "File" menu. Again, the top half of the window allows you to choose the directory and file name to give to your output file — just be careful that you do not overwrite a previous save.
 
 In the left-hand side pull-down menu, select the format of the font you are generating, either <em>TrueType</em> or <em>OpenType (CFF)</em>, as discussed earlier. On the right-hand side, make sure <em>No Bitmap Fonts</em> is selected. On the line below, make sure <em>No Rename</em> is selected for the "Force glyph names to:" option. You can check the "Validate Before Saving" option if you wish (to potentially catch additional errors), but this is optional. Leave the "Append a FONTLOG entry," "Prepend timestamp," and "Upload to the Open Font Library" options unchecked.
 
@@ -111,8 +111,8 @@ Next, click on the "Options" button. Select the <em>PS Glyph Names</em>, <em>Ope
 
 Click the "Generate" button, and FontForge will build your font file. One final ord: it is important not to overwrite the saved version of your FontForge work with the modifications you made in this section solely to generate your <em>.ttf</em> or <em>.otf</em> output.  For example, you lose a lot of individual glyph components when you perform the <em>Remove overlaps</em> operation.  But the next time you resume work on your font, you will definitely want to pick up where you left off in the original, individual-glyph-component-filled version.
 
-Consequently, if you decide to save the modified version of your FontForge file, be sure that you rename it in a memorable way, such as <em>MyFont-TTF.sfd</em> or <em>MyFont-OTF.sfd</em>. But you do not necessarily need to save these output-oriented variations of your file at all -- in practice, the next time you revise your original work in FontForge, you will work through the output preparation steps again anyway.
+Consequently, if you decide to save the modified version of your FontForge file, be sure that you rename it in a memorable way, such as <em>MyFont-TTF.sfd</em> or <em>MyFont-OTF.sfd</em>. But you do not necessarily need to save these output-oriented variations of your file at all — in practice, the next time you revise your original work in FontForge, you will work through the output preparation steps again anyway.
 
 Congratulations are in order! You have now created your first font. All that remains now is for you to share your work: upload it to the web, post it to your blog, and go tell your friends.
 
-Without doubt, you will be back and continue revising and refining your typeface -- after all, as you have seen, font design is a highly iterative process. But be sure that you pause and take this moment to enjoy what you have accomplished first.
+Without doubt, you will be back and continue revising and refining your typeface — after all, as you have seen, font design is a highly iterative process. But be sure that you pause and take this moment to enjoy what you have accomplished first.


### PR DESCRIPTION
`--` sequences are currently being used to represent em-dashes, but kramdown is actually autoconverting these to _en-dashes_ on the jekyll site. From the [kramdown syntax docs](http://kramdown.gettalong.org/syntax.html#typographic-symbols):

> --- will become an em-dash (like this —)
> -- will become an en-dash (like this –)

Replacing `--` with `---` isn’t a clean solution, as the gitbook-generated ebooks aren’t converting double-dashes:

![shot may 31 2016 5 49 58pm](https://cloud.githubusercontent.com/assets/8379226/15693158/23f91a12-2761-11e6-8582-13f9e8ba32c0.jpeg)

The most straightforward fix seems like using the actual utf-8 em-dash character.
