### PR TITLE
No need to configure fontforge to use multi-layers fonts

### DIFF
--- a/en-US/Glossary.md
+++ b/en-US/Glossary.md
@@ -396,13 +396,7 @@ A font in which all glyphs have the same width. These are sometimes called typew
 
 ### Multi-layered fonts
 
-(FontForge's own term) PostScript type3 fonts and SVG fonts allow for more drawing possibilities than normal fonts. Normal fonts may only be filled with a single color inherited from the graphics environment. These two fonts may be filled with several different colors, stroked, include images, have gradient fills, etc.. FontForge can be configured to support these fonts (it does not do so by default because this takes up more memory).
-
-```
-$ configure --with-type3
-$ make
-$ make install
-```
+(FontForge's own term) PostScript type3 fonts and SVG fonts allow for more drawing possibilities than normal fonts. Normal fonts may only be filled with a single color inherited from the graphics environment. These two fonts may be filled with several different colors, stroked, include images, have gradient fills, etc.. 
 
 ### Multiple Master Font
 


### PR DESCRIPTION
Removed instruction to configure fontforge with --with-type3.  This instructions was quite obsolete.  The option changed to --enable-type3 at some point and is now included by default in recent builds (at least since 2014) when the code was moved to Github.  Perhaps even before.

Changed were made in other part of the documentation, see:

https://github.com/fontforge/fontforge/pull/2935
https://github.com/fontforge/fontforge.github.io/pull/108