### PR TITLE
Include country code in HTML's lang attribute too

### DIFF
--- a/_includes/html-start.html
+++ b/_includes/html-start.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.layout | slice: 9, 2 | default: "en" }}">
+<html lang="{{ page.layout | slice: 9, 5 | default: "en" }}">
   <head>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">


### PR DESCRIPTION
The two major Chinese variants are written in different scripts, and browsers usually use different fonts to render them. It would be nice to include a country code for a hint too.

(close #136)