### PR TITLE
Remove Ubuntu PPA links

### DIFF
--- a/en-US/Installing_Fontforge.md
+++ b/en-US/Installing_Fontforge.md
@@ -23,33 +23,7 @@ An [installation guide](http://fontforge.github.io/en-US/downloads/mac/) is avai
 
 The easiest method to get FontForge on your Linux machine is to use your Linux distribution’s package repository.
 
-#### Debian or Ubuntu
-
-The FontForge package included in Ubuntu 14.04 by default dates from 2012, so it is preferable to install the more up-to-date package from the FontForge [Personal Package Archive (PPA)] (https://launchpad.net/~fontforge/+archive/ubuntu/fontforge).
-
-Check that the helper script `add-apt-repository` is installed:
-    
-```sh
-sudo apt-get install software-properties-common;
-```
-
-Add the FontForge PPA (which will also add the authentication key):
-    
-```sh
-sudo add-apt-repository ppa:fontforge/fontforge;
-```
-
-Update the software list to include packages from the PPA:
-    
-```sh
-sudo apt-get update;
-```
-
-Install FontForge:
-    
-```sh
-sudo apt-get install fontforge;
-```
+An [installation guide](http://fontforge.github.io/en-US/downloads/gnulinux/) is available for the official GNU/Linux builds.
 
 #### Fedora
 

--- a/fr-FR/Installing_Fontforge.md
+++ b/fr-FR/Installing_Fontforge.md
@@ -24,33 +24,7 @@ Un [guide d'installation (en anglais)](http://fontforge.github.io/en-US/download
 
 La méthode la plus simple pour obtenir FontForge sur votre machine Linux est d'utiliser le dépôt de paquets de votre distribution Linux.
 
-#### Debian ou Ubuntu
-
-Le paquet FontForge inclus dans Ubuntu 14.04 par défaut date de 2012, il est donc préférable d'installer le paquet plus à jour à partir de la [PPA (Personal Package Archive)](https://launchpad.net/~fontforge/+archive/ubuntu/fontforge) de FontForge.
-
-Vérifiez que le script d'aide `add-apt-repository` est installé:
-    
-```sh
-sudo apt-get install software-properties-common;
-```
-
-Ajoutez la PPA FontForge (qui ajoutera également la clé d'authentification):
-    
-```sh
-sudo add-apt-repository ppa:fontforge/fontforge;
-```
-
-Mettez à jour la liste des logiciels pour inclure les paquets de la PPA:
-    
-```sh
-sudo apt-get update;
-```
-
-Installez FontForge:
-    
-```sh
-sudo apt-get install fontforge;
-```
+Un [guide d'installation (en anglais)](http://fontforge.github.io/en-US/downloads/gnulinux/) est disponible pour les versions officielles GNU/Linux.
 
 #### Fedora
 

--- a/zh-CN/Installing_Fontforge.md
+++ b/zh-CN/Installing_Fontforge.md
@@ -31,33 +31,7 @@ FontForge支持Windows，Mac OS和GNU/Linux (“Linux”)操作系统。本节�
 
 在你的Linux机器上安装FontForge最简单的的方式是使用你的分发版的包库。
 
-#### Debian或Ubuntu
-
-FontForge包从2012年开始就默认包含在Ubuntu 14.04中，因此通过FontForge [Personal Package Archive (PPA)] (https://launchpad.net/~fontforge/+archive/ubuntu/fontforge)可以安装最新的包。
-
-检查辅助脚本`add-apt-repository`已经安装：
-    
-```
-sudo apt-get install software-properties-common
-```
-
-添加FontForge PPA（同时添加认证密钥）：
-    
-```
-sudo add-apt-repository ppa:fontforge/fontforge
-```
-
-升级软件列表，使得PPA包含包：
-    
-```
-sudo apt-get update
-```
-
-安装FontForge：
-    
-```
-sudo apt-get install fontforge
-```
+正在建设中的新网站上提供了[安装指南](http://fontforge.github.io/en-US/downloads/gnulinux/)。
 
 #### Fedora
 


### PR DESCRIPTION
**[why]**
The PPAs (community build packages) are deprecated by the fontforge docu
itself:

https://fontforge.org/en-US/downloads/gnulinux-dl/

> The Ubuntu PPA, and similar distribution-specific build platforms that
> put the onus on us, are deprecated and not to be used.

Furthermore there are no current builds available anymore.

**[how]**
As with the Windows and Mac sections change the link to the fontforge
website and do not provide a separate (possibly outdated) instruction.

Came up here: https://github.com/ryanoasis/nerd-fonts/issues/725

Reported-by: Aniket Teredesai <a@aniketteredesai.com>

