### PR TITLE
Remove text related to including spiro in installation

### DIFF
--- a/en-US/Drawing_With_Spiro.md
+++ b/en-US/Drawing_With_Spiro.md
@@ -7,11 +7,8 @@ title: Drawing with Spiro
 ---
 
 Spiro is a toolkit for designing curves in an alternate method to the more traditional B&eacute;zier
-curves. Although it is optional, FontForge can be installed to include a Spiro mode that offers you
-tools to create this specific kind of curves.  
-See [“Installing FontForge”] for more details on how to include the Spiro library in your program.
-
-Spiro drawing has a different approach, that can help you getting your curves done in a different
+curves.
+It has a different approach, that can help you getting your curves done in a different
 way and solving your conception problems. Please experiment!
 
 ## The Spiro toolset

--- a/fr-FR/Drawing_With_Spiro.md
+++ b/fr-FR/Drawing_With_Spiro.md
@@ -7,11 +7,7 @@ title: Dessin avec Spiro
 ---
 
 Spiro est une boîte à outils pour concevoir des courbes avec une méthode alternative aux courbes de
-B&eacute;zier plus traditionnelles. Bien que cela soit facultatif, FontForge peut être installé pour
-inclure un mode Spiro qui vous offre des outils pour créer ce type spécifique de courbes. Voir
-[“Installation de FontForge"] pour plus de détails sur la façon d'inclure la bibliothèque Spiro dans
-votre programme.
-
+B&eacute;zier plus traditionnelles.
 Le dessin avec Spiro a une approche différente, qui peut vous aider à obtenir des courbes faites d'une
 autre manière et à résoudre vos problèmes de conception. Veuillez expérimentez!
 

--- a/zh-CN/Drawing_With_Spiro.md
+++ b/zh-CN/Drawing_With_Spiro.md
@@ -6,8 +6,7 @@ category: Getting To Know FontForge
 title: 使用Spiro绘制
 ---
 
-Spiro是一个使用更传统的B&eacute;zier曲线的替换方法来设计曲线的工具包。 尽管这是可选择的，FontForge可以包含Spiro模式安装，提供给你创造特定类型曲线的工具。如何在你的程序中包含Spiro库的详细信息参见[“安装FontForge”][“Installing FontForge”]。
-
+Spiro是一个使用更传统的B&eacute;zier曲线的替换方法来设计曲线的工具包。
 Spiro绘制是一个不同的方法，可以用不同的方式完成你的曲线，解决你概念上的问题。请试验一下！
 
 ## Spiro工具集


### PR DESCRIPTION
Spiro drawing tools are already included in FontForge in its current releases.

Closes #244