### PR TITLE
Remove duplicate link

### DIFF
--- a/fa-IR/Further_Reading.md
+++ b/fa-IR/Further_Reading.md
@@ -102,8 +102,7 @@ title: مطالعهٔ بیشتر
 
 ### فارسی
 
-* [Getting started with FontForge](https://rastikerdar.github.io/getting-started-with-fontforge/) By Saber Rastikerdar (RIP)
-  [شروع با فونت‌فورج](https://rastikerdar.github.io/getting-started-with-fontforge/) به قلم صابر راستی‌کردار (یادش گرامی)
+* [شروع با فونت‌فورج](https://rastikerdar.github.io/getting-started-with-fontforge/) به قلم صابر راستی‌کردار (یادش گرامی)
 
 ## کتاب‌ها
 


### PR DESCRIPTION
In Persian page for "further reading", we don't need to have English translation for Persian resources.