### PR TITLE
JP translation update in Chapters 6 & 9.

### DIFF
--- a/ja-JP/Installing_Fontforge.md
+++ b/ja-JP/Installing_Fontforge.md
@@ -22,14 +22,11 @@ Dr Ben Martin 氏が作成した公式 Mac 版の[インストール・ガイド
 
 Linux マシンに FontForge をインストールする最も簡単な方法は、使用している Linux ディストリビューションのパッケージ・リポジトリを使用することです。
 
-An [installation guide](http://fontforge.github.io/en-US/downloads/gnulinux/) is available for the official GNU/Linux builds.
+公式 GNU/Linux 版の「 [インストール・ガイド](http://fontforge.github.io/en-US/downloads/gnulinux/)」（英語版）が利用可能です。
 
-### Installing older versions of FontForge
+### 「FontForge」の古いバージョンをインストールする
 
-Users who need an older version of Fontforge can look for stable releases
-[here](https://github.com/fontforge/fontforge/releases), and
-[here](https://sourceforge.net/projects/fontforgebuilds/), and older releases prior to 2012
-[here](http://sourceforge.net/projects/fontforge/files/fontforge-executables/).
+FontForge の古いバージョンが必要なユーザーの方には、安定版が「[こちら](https://github.com/fontforge/fontforge/releases)」か「[こちら](https://sourceforge.net/projects/fontforgebuilds/)」で、2012 より前のリリース版は「[こちら](http://sourceforge.net/projects/fontforge/files/fontforge-executables/)」で見つけられるはずです。
 
 ## GitHub から自分自身のバージョンをコンパイルする
 

--- a/ja-JP/Using_the_Fontforge_Drawing_Tools.md
+++ b/ja-JP/Using_the_Fontforge_Drawing_Tools.md
@@ -6,15 +6,15 @@ category: Getting To Know FontForge
 title: FontForge の描画ツールを使用する
 ---
 
->>> 《訳注》FontForge 20230101 版では、メニュー項目やポップアップ項目に**日本語化されていない**部分があります。
+> 《訳注》FontForge 20230101 版では、メニュー項目やポップアップ項目に**日本語化されていない**部分があります。
 
->>> 《訳注》ベジェ曲線関係の用語の訳語は以下のとおりです。
->>> + 変化点 breaks
->>> + 曲線点 Curve points / Anchor points
->>> + H/V 曲線点 horizontal/vertical curve points
->>> + 角の点 Corner points / Coins
->>> + 方向点 Handle points
->>> + 接点 Tangent points
+> 《訳注》ベジェ曲線関係の用語の訳語は以下のとおりです。
+> + 変化点 breaks
+> + 曲線点 Curve points / Anchor points
+> + H/V 曲線点 horizontal/vertical curve points
+> + 角の点 Corner points / Coins
+> + 方向点 Handle points
+> + 接点 Tangent points
 
 <p> </br></p>
 


### PR DESCRIPTION
Chapter 6:  Remained English texts are translated (lines 25 - 29).

Chapter 9: Tried to adjust the font size in the indented section (currently the fonts are shown too large compared to the header/text lines as below:) .

[9_font_size_to_large](https://github.com/user-attachments/assets/3407baa9-6b22-41c3-95cd-cc8fd4c514ba)

Indentation (>) in the .md file is changed from '>>>' to '>' (from three to one indentation). If this works OK, the similar issues in other chapters will be also corrected.